### PR TITLE
Fix chunk_size defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install kara-toolkit[langchain]
 | Parameter                   | Type         | Default | Description                                                                                                                                                                                                                 |
 |-----------------------------|--------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `imperfect_chunk_tolerance` | `int`        | `9`     | Controls the trade-off between reusing existing chunks and creating new, perfectly-sized ones.<br><br>- `0`: No tolerance; disables chunk reuse.<br>- `1`: Prefers new chunk over two imperfect ones.<br>- `9`: Balanced default.<br>- `99+`: Maximizes reuse, less uniform sizes. |
-| `chunk_size`                | `int`        | `500`   | Target size (in characters) for each text chunk.                                                                                                                                                                            |
+| `chunk_size`                | `int`        | `4000`   | Target size (in characters) for each text chunk.                                                                                                                                                                            |
 | `separators`                | `List[str]`  | `["\n\n", "\n", " "]`       | List of strings used to split the text. If not provided, uses default separators from `RecursiveCharacterChunker`.                                                                     |
 
 ## Quick Start

--- a/src/kara/splitters.py
+++ b/src/kara/splitters.py
@@ -97,7 +97,7 @@ class RecursiveCharacterChunker(BaseDocumentChunker):
 
         Args:
             separators: List of separators to try, in order of preference
-            chunk_size: Maximum chunk size in characters
+            chunk_size: Maximum chunk size in characters. Defaults to 4000
             overlap: Overlap between chunks (not implemented yet)
             keep_separator: Whether to keep separators in the result
         """


### PR DESCRIPTION
## Summary
- correct default value for `chunk_size` in README table
- clarify default near `RecursiveCharacterChunker` initializer

## Testing
- `pre-commit run --files README.md src/kara/splitters.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875425130ac832cb99a5c7b5d745bdc